### PR TITLE
Avoid calling model_fields on instance

### DIFF
--- a/pydantic_apply/_compat.py
+++ b/pydantic_apply/_compat.py
@@ -54,7 +54,7 @@ elif PYDANTIC_V2:  # pragma: no cover
 
         @property
         def model_fields(self) -> dict[str, FieldInfo]:
-            return self.obj.model_fields
+            return self.obj.__class__.model_fields
 
         @property
         def __pydantic_fields_set__(self) -> set[str]:


### PR DESCRIPTION
The ability to call `model_fields` on instances will be removed in pydantic 3 and throws deprecation warnings since 2.11 - which breaks tests and pipelines if you configure warnings to be errors.