### PR TITLE
Fix applying multiple attributes at once

### DIFF
--- a/pydantic_apply/apply.py
+++ b/pydantic_apply/apply.py
@@ -103,7 +103,7 @@ class ApplyModelMixin(pydantic.BaseModel):
                 }
 
             for field_name, field_value in prepared_changes.items():
-                setattr(self, field_name, field_value)
+                setattr(self_compat, field_name, field_value)
 
         finally:
             # Ensure whatever happens here, the validate_assignment flag is reset


### PR DESCRIPTION
Imagine you need to apply two related attributes at the same time, because updating just one would result in an invalid state.

This would currently be broken, because `self` still has `validate_assignment=True`, which should be disabled temporarily.
