### PR TITLE
Fix for setattr handlers for pydantic 2.11

### DIFF
--- a/pydantic_apply/_compat.py
+++ b/pydantic_apply/_compat.py
@@ -1,5 +1,3 @@
-from collections.abc import Generator
-from contextlib import contextmanager
 from typing import Any
 
 import pydantic
@@ -44,10 +42,6 @@ if PYDANTIC_V1:  # pragma: no cover
 
         def model_dump(self, **kwargs: Any) -> dict[str, Any]:
             return self.obj.dict(**kwargs)
-
-        @contextmanager
-        def disable_setattr_handler_cache(self) -> Generator[None, Any, Any]:
-            yield
 
 
 elif PYDANTIC_V2:  # pragma: no cover

--- a/pydantic_apply/_compat.py
+++ b/pydantic_apply/_compat.py
@@ -1,5 +1,5 @@
 from typing import Any
-from contextlib import contextmanger
+from contextlib import contextmanager
 from packaging.version import Version
 
 import pydantic
@@ -43,7 +43,7 @@ if PYDANTIC_V1:  # pragma: no cover
         def model_dump(self, **kwargs: Any) -> dict[str, Any]:
             return self.obj.dict(**kwargs)
 
-        @contextmanger
+        @contextmanager
         def disable_setattr_handler_cache(self) -> None:
             yield
 
@@ -83,7 +83,7 @@ elif PYDANTIC_V2:  # pragma: no cover
         def model_dump(self, **kwargs: Any) -> dict[str, Any]:
             return self.obj.model_dump(**kwargs)
 
-        @contextmanger
+        @contextmanager
         def disable_setattr_handler_cache(self) -> None:
             if Version(PYDANTIC_VERSION) >= Version("2.11"):
                 old_setattr_handlers = self.obj.__pydantic_setattr_handlers__

--- a/pydantic_apply/_compat.py
+++ b/pydantic_apply/_compat.py
@@ -1,8 +1,8 @@
-from typing import Any
 from contextlib import contextmanager
-from packaging.version import Version
+from typing import Any
 
 import pydantic
+from packaging.version import Version
 from pydantic.fields import FieldInfo
 from pydantic.version import VERSION as PYDANTIC_VERSION
 
@@ -93,4 +93,3 @@ elif PYDANTIC_V2:  # pragma: no cover
 
             if Version(PYDANTIC_VERSION) >= Version("2.11"):
                 self.obj.__pydantic_setattr_handlers__ = old_setattr_handlers
-

--- a/pydantic_apply/_compat.py
+++ b/pydantic_apply/_compat.py
@@ -88,7 +88,7 @@ elif PYDANTIC_V2:  # pragma: no cover
         def disable_setattr_handler_cache(self) -> Generator[None, Any, Any]:
             old_setattr_handlers = {}
             if Version(PYDANTIC_VERSION) >= Version("2.11"):
-                old_setattr_handlers = self.obj.__pydantic_setattr_handlers__
+                old_setattr_handlers = self.obj.__class__.__pydantic_setattr_handlers__
                 self.obj.__class__.__pydantic_setattr_handlers__ = {}
 
             yield

--- a/pydantic_apply/_compat.py
+++ b/pydantic_apply/_compat.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any
 
@@ -44,7 +45,7 @@ if PYDANTIC_V1:  # pragma: no cover
             return self.obj.dict(**kwargs)
 
         @contextmanager
-        def disable_setattr_handler_cache(self) -> None:
+        def disable_setattr_handler_cache(self) -> Generator[None, Any, Any]:
             yield
 
 
@@ -84,12 +85,13 @@ elif PYDANTIC_V2:  # pragma: no cover
             return self.obj.model_dump(**kwargs)
 
         @contextmanager
-        def disable_setattr_handler_cache(self) -> None:
+        def disable_setattr_handler_cache(self) -> Generator[None, Any, Any]:
+            old_setattr_handlers = {}
             if Version(PYDANTIC_VERSION) >= Version("2.11"):
                 old_setattr_handlers = self.obj.__pydantic_setattr_handlers__
-                self.obj.__pydantic_setattr_handlers__ = {}
+                self.obj.__class__.__pydantic_setattr_handlers__ = {}
 
             yield
 
             if Version(PYDANTIC_VERSION) >= Version("2.11"):
-                self.obj.__pydantic_setattr_handlers__ = old_setattr_handlers
+                self.obj.__class__.__pydantic_setattr_handlers__ = old_setattr_handlers

--- a/pydantic_apply/_compat.py
+++ b/pydantic_apply/_compat.py
@@ -9,6 +9,7 @@ from pydantic.version import VERSION as PYDANTIC_VERSION
 
 PYDANTIC_V1 = PYDANTIC_VERSION.startswith("1.")
 PYDANTIC_V2 = PYDANTIC_VERSION.startswith("2.")
+PYDANTIC_GE_V2_11 = Version(PYDANTIC_VERSION) >= Version("2.11")
 
 
 if PYDANTIC_V1:  # pragma: no cover
@@ -83,15 +84,3 @@ elif PYDANTIC_V2:  # pragma: no cover
 
         def model_dump(self, **kwargs: Any) -> dict[str, Any]:
             return self.obj.model_dump(**kwargs)
-
-        @contextmanager
-        def disable_setattr_handler_cache(self) -> Generator[None, Any, Any]:
-            old_setattr_handlers = {}
-            if Version(PYDANTIC_VERSION) >= Version("2.11"):
-                old_setattr_handlers = self.obj.__class__.__pydantic_setattr_handlers__
-                self.obj.__class__.__pydantic_setattr_handlers__ = {}
-
-            yield
-
-            if Version(PYDANTIC_VERSION) >= Version("2.11"):
-                self.obj.__class__.__pydantic_setattr_handlers__ = old_setattr_handlers

--- a/pydantic_apply/apply.py
+++ b/pydantic_apply/apply.py
@@ -4,7 +4,7 @@ from typing import Any, Union, cast
 import pydantic
 
 from pydantic_apply._compat import PydanticCompat
-from pydantic_apply.utils import is_pydantic_apply_annotation
+from pydantic_apply.utils import assignment_validation_context, is_pydantic_apply_annotation
 
 
 class ApplyModelMixin(pydantic.BaseModel):
@@ -71,45 +71,9 @@ class ApplyModelMixin(pydantic.BaseModel):
             # Default apply: Just set new value
             prepared_changes[field_name] = changed_field_value
 
-        # Apply changes
-        had_validate_assignment = self_compat.get_model_config_value("validate_assignment")
-        try:
-            if had_validate_assignment:
-                # Disable validation on assignment so we can apply the whole set of
-                # changes without validation problems while the data changes. This
-                # is necessary as validators may depend on other fields. When we change
-                # the fields one by one, the validators may fail as the temporary
-                # combination of two values will not validate. But the validator might
-                # have passed when we would have had the chance to set both values.
-                self_compat.set_model_config_value("validate_assignment", False)
-
-                # Run validation as if all changes were applied. We do this by creating
-                # a new (temporary) instance of the model class, just to run the
-                # validation.
-                changed_self = self.__class__(
-                    **{
-                        **self_compat.model_dump(),
-                        **prepared_changes,
-                    },
-                )
-
-                # Update the changes with the validated values we now have from the
-                # temporary instance.
-                prepared_changes = {
-                    key: value
-                    for key, value
-                    in changed_self.__dict__.items()
-                    if key in prepared_changes.keys()
-                }
-
+        with assignment_validation_context(self_compat, prepared_changes):
             for field_name, field_value in prepared_changes.items():
-                with self_compat.disable_setattr_handler_cache():
-                    setattr(self, field_name, field_value)
-
-        finally:
-            # Ensure whatever happens here, the validate_assignment flag is reset
-            # to its original value.
-            self_compat.set_model_config_value("validate_assignment", had_validate_assignment)
+                setattr(self, field_name, field_value)
 
     def apply(
         self,

--- a/pydantic_apply/apply.py
+++ b/pydantic_apply/apply.py
@@ -103,7 +103,8 @@ class ApplyModelMixin(pydantic.BaseModel):
                 }
 
             for field_name, field_value in prepared_changes.items():
-                setattr(self, field_name, field_value)
+                with self_compat.disable_setattr_handler_cache():
+                    setattr(self, field_name, field_value)
 
         finally:
             # Ensure whatever happens here, the validate_assignment flag is reset

--- a/pydantic_apply/apply.py
+++ b/pydantic_apply/apply.py
@@ -71,8 +71,8 @@ class ApplyModelMixin(pydantic.BaseModel):
             # Default apply: Just set new value
             prepared_changes[field_name] = changed_field_value
 
-        with assignment_validation_context(self_compat, prepared_changes):
-            for field_name, field_value in prepared_changes.items():
+        with assignment_validation_context(self_compat, prepared_changes) as changes_in_context:
+            for field_name, field_value in changes_in_context.items():
                 setattr(self, field_name, field_value)
 
     def apply(

--- a/pydantic_apply/utils.py
+++ b/pydantic_apply/utils.py
@@ -120,7 +120,7 @@ def reset_setattr_handler_cache(
 def assignment_validation_context(
     self_compat: PydanticCompat,
     prepared_changes: dict[str, Any],
-) -> None:
+) -> Generator[None, None, None]:
     """
     Context for assigning values.
 

--- a/pydantic_apply/utils.py
+++ b/pydantic_apply/utils.py
@@ -126,9 +126,7 @@ def assignment_validation_context(
 
     This context handles assigning multiple values at once while providing
     compatibility across pydantic versions.
-    Since this requires some temporary changes, we need to reset
-    everything in the __exit__ method, which is also the reason
-    why this is not a simple contextmanager method.
+    This requires some temporary changes, we need to reset on exit.
     """
 
     old_prepared_changes = prepared_changes

--- a/pydantic_apply/utils.py
+++ b/pydantic_apply/utils.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any, Union, get_args, get_origin
 

--- a/pydantic_apply/utils.py
+++ b/pydantic_apply/utils.py
@@ -34,7 +34,7 @@ def is_pydantic_apply_annotation(annotation: type) -> bool:
 def assignment_validation_context(
     self_compat: PydanticCompat,
     prepared_changes: dict[str, Any],
-) -> Generator[None, None, None]:
+) -> Generator[dict[str, Any], None, None]:
     """
     Context for assigning values.
 

--- a/pydantic_apply/utils.py
+++ b/pydantic_apply/utils.py
@@ -1,6 +1,9 @@
-from typing import Union, get_args, get_origin
+from contextlib import contextmanager
+from typing import Any, Union, get_args, get_origin
 
 import pydantic_apply
+
+from ._compat import PYDANTIC_GE_V2_11, PydanticCompat
 
 
 def is_pydantic_apply_annotation(annotation: type) -> bool:
@@ -24,3 +27,120 @@ def is_pydantic_apply_annotation(annotation: type) -> bool:
 
     # If we did not detect an ApplyModelMixin annotation, return False
     return False
+
+
+def prepare_validate_assignment_config(
+    self_compat: PydanticCompat,
+    state_cache: dict[str, Any],
+    prepared_changes: dict[str, Any],
+) -> None:
+    """
+    Create a temporary model to validate and prepare the values.
+    """
+
+    had_validate_assignment = self_compat.get_model_config_value("validate_assignment")
+    state_cache["validate_assignment"] = had_validate_assignment
+    if had_validate_assignment:
+        # Disable validation on assignment so we can apply the whole set of
+        # changes without validation problems while the data changes. This
+        # is necessary as validators may depend on other fields. When we change
+        # the fields one by one, the validators may fail as the temporary
+        # combination of two values will not validate. But the validator might
+        # have passed when we would have had the chance to set both values.
+        self_compat.set_model_config_value("validate_assignment", False)
+
+        # Run validation as if all changes were applied. We do this by creating
+        # a new (temporary) instance of the model class, just to run the
+        # validation.
+        changed_self = self_compat.obj.__class__(
+            **{
+                **self_compat.model_dump(),
+                **prepared_changes,
+            },
+        )
+
+        # Update the changes with the validated values we now have from the
+        # temporary instance.
+        prepared_changes = {
+            key: value
+            for key, value
+            in changed_self.__dict__.items()
+            if key in prepared_changes.keys()
+        }
+
+
+def reset_validate_assigment_config(
+    self_compat: PydanticCompat,
+    state_cache: dict[str, Any],
+    prepared_changes: dict[str, Any],  # noqa: ARG001 unused argument
+) -> None:
+    """
+    Ensure that the validate_assignment flag is reset to its original value.
+    """
+
+    self_compat.set_model_config_value(
+        "validate_assignment",
+        state_cache.pop("validate_assignment", None),
+    )
+
+
+def prepare_setattr_handler_cache(
+    self_compat: PydanticCompat,
+    state_cache: dict[str, Any],
+    prepared_changes: dict[str, Any],  # noqa: ARG001 unused argument
+) -> None:
+    """
+    Empty the cache of setattr handlers.
+
+    This is needed, because otherwise assigning multiple attributes could fail
+    if the respective validators already have been initialized.
+    """
+
+    state_cache["__pydantic_setattr_handlers__"] = {}
+    if PYDANTIC_GE_V2_11:
+        state_cache["__pydantic_setattr_handlers__"] = self_compat.obj.__class__.__pydantic_setattr_handlers__
+        self_compat.obj.__class__.__pydantic_setattr_handlers__ = {}
+
+
+def reset_setattr_handler_cache(
+    self_compat: PydanticCompat,
+    state_cache: dict[str, Any],
+    prepared_changes: dict[str, Any],  # noqa: ARG001 unused argument
+) -> None:
+    """Reset the setattr handler cache to its original state."""
+
+    if PYDANTIC_GE_V2_11:
+        self_compat.obj.__class__.__pydantic_setattr_handlers__ = state_cache.pop(
+            "__pydantic_setattr_handlers__",
+            {},
+        )
+
+
+@contextmanager
+def assignment_validation_context(
+    self_compat: PydanticCompat,
+    prepared_changes: dict[str, Any],
+) -> None:
+    """
+    Context for assigning values.
+
+    This context handles assigning multiple values at once while providing
+    compatibility across pydantic versions.
+    Since this requires some temporary changes, we need to reset
+    everything in the __exit__ method, which is also the reason
+    why this is not a simple contextmanager method.
+    """
+
+    old_prepared_changes = prepared_changes
+    state_cache = {}
+    try:
+        prepare_validate_assignment_config(self_compat, state_cache, old_prepared_changes)
+        prepare_setattr_handler_cache(self_compat, state_cache, old_prepared_changes)
+
+        yield
+
+    finally:
+        reset_validate_assigment_config(self_compat, state_cache, old_prepared_changes)
+        reset_setattr_handler_cache(self_compat, state_cache, old_prepared_changes)
+
+        prepared_changes = old_prepared_changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.9"
 pydantic = ">=1.9.0,<3.0.0"
+packaging = "^25.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.1.2,<9.0.0"

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -186,8 +186,9 @@ def test_apply_will_handle_inner_apply_model():
 
 
 def test_apply_will_handle_inner_apply_model_with_validate_assignment():
-    inner_with_apply = InnerWithApplyModel(a=1)
-    obj = ApplyModelWithValidation(a=1, b=2, inner_with_apply=inner_with_apply)
+    obj = ApplyModelWithValidation(a=1, b=2, inner_with_apply=InnerWithApplyModel(a=1))
+    # Get the value of inner_with_apply afterwards because it might already have changed once
+    inner_with_apply = obj.inner_with_apply
 
     obj.model_apply({
         "inner_with_apply": PatchModel(b=1),

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -136,10 +136,18 @@ def test_apply_will_handle_validate_assignment():
 
 
 def test_apply_will_handle_validate_assignment_after_direct_access():
+    """
+    Test that model_apply works with initialized setattr cache.
+
+    This is only necessary starting from pydantic v2.11, since when
+    setattr uses a chache which stores the validate_assignment setting.
+    """
+
     obj = ApplyModelWithAfterValidation(a=1, b=2)
-    obj.a = 3
+    obj.a = 3  # First apply both values to initialize __pydantic_setattr_handlers__
     obj.b = 4
 
+    # model_apply temporarily needs to disable the cache to skip the assignment validation
     obj.model_apply({"a": 4, "b": 3})
 
     assert obj.a == 4

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -178,8 +178,8 @@ def test_apply_will_handle_inner_apply_model():
 
 
 def test_apply_will_handle_inner_apply_model_with_validate_assignment():
-    obj = ApplyModelWithValidation(a=1, b=2, inner_with_apply=InnerWithApplyModel(a=1))
-    inner_with_apply = obj.inner_with_apply
+    inner_with_apply = InnerWithApplyModel(a=1)
+    obj = ApplyModelWithValidation(a=1, b=2, inner_with_apply=inner_with_apply)
 
     obj.model_apply({
         "inner_with_apply": PatchModel(b=1),


### PR DESCRIPTION
Pydantic 2.11 introduced a cache of setattr handlers. This breaks applying multiple values if these fields have been accessed before, because then the `validate_assigment` config is set and validation is executed anyway.